### PR TITLE
Only setup JC on management account

### DIFF
--- a/org-formation/600-access/organization-tasks.yaml
+++ b/org-formation/600-access/organization-tasks.yaml
@@ -19,7 +19,8 @@ AccessTestItOrgMgntAdmin:
     SamlProviderName: testitorgmgnt-admin
     SamlProviderPolicyArns:
       - arn:aws:iam::aws:policy/AdministratorAccess
+      -
   DefaultOrganizationBinding:
     IncludeMasterAccount: true
-    Account: '*'
+    Account: '928879890086'
     Region: us-east-1


### PR DESCRIPTION
We only have to bootstrap JC for management account because member
accounts can be accessed thru the management account.