### PR TITLE
Remove default vpc from all accounts

### DIFF
--- a/org-formation/300-account-defaults/ec2-no-default-vpc.yaml
+++ b/org-formation/300-account-defaults/ec2-no-default-vpc.yaml
@@ -1,0 +1,4 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  NoDefaultVpc:
+    Type: 'Community::Organizations::NoDefaultVPC'

--- a/org-formation/300-account-defaults/organization-tasks.yaml
+++ b/org-formation/300-account-defaults/organization-tasks.yaml
@@ -18,3 +18,24 @@ Ec2EbsEncryptionDefaults:
     IncludeMasterAccount: true
     Account: '*'
     Region: us-east-1
+
+CommunityEc2NoDefaultVpcRP:
+  Type: register-type
+  SchemaHandlerPackage: s3://community-resource-provider-catalog/community-organizations-nodefaultvpc-0.1.0.zip
+  ResourceType: 'Community::Organizations::NoDefaultVPC'
+  MaxConcurrentTasks: 10
+  OrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+    Region: us-east-1
+
+Ec2NoVpcDefaults:
+  Type: update-stacks
+  Template: ./ec2-no-default-vpc.yaml
+  DependsOn: CommunityEc2NoDefaultVpcRP
+  StackName: ec2-no-default-vpc
+  MaxConcurrentStacks: 10
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+    Region: us-east-1


### PR DESCRIPTION
The default VPC provided by AWS is inherently non-secure because
it only contains public subnets.  We remove the default
VPC on every account that is created.