### PR TITLE
Setup resources for sceptre

### DIFF
--- a/org-formation/300-account-defaults/organization-tasks.yaml
+++ b/org-formation/300-account-defaults/organization-tasks.yaml
@@ -39,3 +39,23 @@ Ec2NoVpcDefaults:
     IncludeMasterAccount: true
     Account: '*'
     Region: us-east-1
+
+SceptreCloudformationBucket:
+  Type: update-stacks
+  Template: ./public-bucket.yaml
+  StackName: sceptre-cloudformation-bucket
+  MaxConcurrentStacks: 10
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+    Region: us-east-1
+
+SceptreLambdaBucket:
+  Type: update-stacks
+  Template: ./public-bucket.yaml
+  StackName: sceptre-lambda-bucket
+  MaxConcurrentStacks: 10
+  DefaultOrganizationBinding:
+    IncludeMasterAccount: true
+    Account: '*'
+    Region: us-east-1

--- a/org-formation/300-account-defaults/public-bucket.yaml
+++ b/org-formation/300-account-defaults/public-bucket.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Bucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: PublicRead
+  BucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref Bucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "AllowPublicRead"
+            Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action: "s3:GetObject"
+            Resource: !Sub "arn:aws:s3:::${Bucket}/*"


### PR DESCRIPTION
We plan to run sceptre in parallel to org-formation so we need to
setup a cloudformation and lambda bucket for every member account to
allow sceptre to deploy resources.